### PR TITLE
Simplify installation of sfdx

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,12 @@ sudo: true
 
 dist: trusty 
 
-env:
-  - URL=https://developer.salesforce.com/media/salesforce-cli/sfdx-linux-amd64.tar.xz
-
 addons:
   chrome: stable
 
 before_install:
   - openssl aes-256-cbc -K $encrypted_64814298f594_key -iv $encrypted_64814298f594_iv -in assets/server.key.enc -out assets/server.key -d  
-  - wget -qO- $URL | tar xJf -
-  - ./sfdx/install
+  - npm install -g sfdx-cli
 
 before_script:
   - "export DISPLAY=:99.0"

--- a/circle.yml
+++ b/circle.yml
@@ -1,4 +1,6 @@
 machine:
+  node:
+    version: 8.4.0
   environment:
     SFDX_AUTOUPDATE_DISABLE: true
     SFDX_USE_GENERIC_UNIX_KEYCHAIN: true

--- a/circle.yml
+++ b/circle.yml
@@ -6,14 +6,14 @@ machine:
     SFDX_USE_GENERIC_UNIX_KEYCHAIN: true
     SFDX_DOMAIN_RETRY: 300
 
-  dependencies:
-    pre:
-      - curl -L -o google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-      - sudo dpkg -i google-chrome.deb
-      - sudo sed -i 's|HERE/chrome\"|HERE/chrome\" --disable-setuid-sandbox|g' /opt/google/chrome/google-chrome
-      - rm google-chrome.deb
-    post:
-      - npm install -g sfdx-cli
+dependencies:
+  pre:
+    - curl -L -o google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+    - sudo dpkg -i google-chrome.deb
+    - sudo sed -i 's|HERE/chrome\"|HERE/chrome\" --disable-setuid-sandbox|g' /opt/google/chrome/google-chrome
+    - rm google-chrome.deb
+  post:
+    - npm install -g sfdx-cli
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -5,8 +5,7 @@ machine:
     SFDX_DOMAIN_RETRY: 300
 
   pre:
-    - wget -qO- https://developer.salesforce.com/media/salesforce-cli/sfdx-linux-amd64.tar.xz | tar xJf -
-    - ./sfdx/install
+    - npm install -g sfdx-cli
     - curl -L -o google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
     - sudo dpkg -i google-chrome.deb
     - sudo sed -i 's|HERE/chrome\"|HERE/chrome\" --disable-setuid-sandbox|g' /opt/google/chrome/google-chrome

--- a/circle.yml
+++ b/circle.yml
@@ -8,11 +8,12 @@ machine:
 
   dependencies:
     pre:
-      - npm install -g sfdx-cli
       - curl -L -o google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
       - sudo dpkg -i google-chrome.deb
       - sudo sed -i 's|HERE/chrome\"|HERE/chrome\" --disable-setuid-sandbox|g' /opt/google/chrome/google-chrome
       - rm google-chrome.deb
+    post:
+      - npm install -g sfdx-cli
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -6,12 +6,13 @@ machine:
     SFDX_USE_GENERIC_UNIX_KEYCHAIN: true
     SFDX_DOMAIN_RETRY: 300
 
-  pre:
-    - npm install -g sfdx-cli
-    - curl -L -o google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-    - sudo dpkg -i google-chrome.deb
-    - sudo sed -i 's|HERE/chrome\"|HERE/chrome\" --disable-setuid-sandbox|g' /opt/google/chrome/google-chrome
-    - rm google-chrome.deb
+  dependencies:
+    pre:
+      - npm install -g sfdx-cli
+      - curl -L -o google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+      - sudo dpkg -i google-chrome.deb
+      - sudo sed -i 's|HERE/chrome\"|HERE/chrome\" --disable-setuid-sandbox|g' /opt/google/chrome/google-chrome
+      - rm google-chrome.deb
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -5,13 +5,13 @@ machine:
     SFDX_AUTOUPDATE_DISABLE: true
     SFDX_USE_GENERIC_UNIX_KEYCHAIN: true
     SFDX_DOMAIN_RETRY: 300
-
-dependencies:
   pre:
     - curl -L -o google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
     - sudo dpkg -i google-chrome.deb
     - sudo sed -i 's|HERE/chrome\"|HERE/chrome\" --disable-setuid-sandbox|g' /opt/google/chrome/google-chrome
     - rm google-chrome.deb
+    
+dependencies:
   post:
     - npm install -g sfdx-cli
 


### PR DESCRIPTION
There is a new way to install that will be the recommended way moving forward for CI jobs – just use `npm install -g sfdx-cli`.