### PR TITLE
Capture __coverage__ information for extraction

### DIFF
--- a/lightning-component-tests/test/default/staticresources/lts_testutil.resource
+++ b/lightning-component-tests/test/default/staticresources/lts_testutil.resource
@@ -181,6 +181,7 @@
             },
             jasmineDone: function(result) {
                 setHiddenDivContent("run_results_full", JSON.stringify(run_results_full));
+                setHiddenDivContent("coverage_results_full", JSON.stringify(window.__coverage__));
             }
         };
 
@@ -207,6 +208,7 @@
             run_results_full.tests.push(convertMochaTestEventToSfdxTestResult(pendingTest));
         }).on('end', function (suite) {
             setHiddenDivContent("run_results_full", JSON.stringify(run_results_full));
+            setHiddenDivContent("coverage_results_full", JSON.stringify(window.__coverage__));
         });
     }
 


### PR DESCRIPTION
If JS has been instrumented by Istanbul it logs its coverage information into the `window.__coverage__` variable. To pull coverage information down to the client it must be stored in a div, exactly the same as the test runner.

Might still have some issues related to crossing LockerService boundaries but will cover most use cases.

(newline added by GitHub editor but decided to leave the change, feel free to reject and I can adjust)